### PR TITLE
Revert "Update inquirer to version 1.3.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@blinkmobile/blinkmrc": "1.1.0",
     "aws-sdk": "2.7.7",
     "base64url": "2.0.0",
-    "inquirer": "1.3.0",
+    "inquirer": "1.2.3",
     "jsonwebtoken": "7.1.9",
     "lodash.memoize": "4.1.2",
     "opn": "4.0.2",


### PR DESCRIPTION
-   Reverts blinkmobile/bm-identity.js#21

-   [inquirer](https://www.npmjs.com/package/inquirer) never published [1.3.0](https://github.com/SBoudrias/Inquirer.js/releases/tag/v1.3.0) to npm:

    > Unpublished due to backward compatibility issue