### PR TITLE
AUTH-16 # Extra ^ in query string on Windows

### DIFF
--- a/lib/login-providers/browser.js
+++ b/lib/login-providers/browser.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const querystring = require('querystring');
 const crypto = require('crypto');
 const request = require('request');
 const inquirer = require('inquirer');
@@ -36,18 +37,18 @@ class BrowserLoginProvider extends LoginProviderBase {
     // Generate the verifier, and the corresponding challenge
     const verifier = base64url(crypto.randomBytes(32));
     const verifierChallenge = base64url(crypto.createHash('sha256').update(verifier).digest());
-
+    const qs = querystring.stringify({
+      response_type: 'code',
+      scope: 'openid refreshIdTokenBeforeSeconds serviceSettingsUrl',
+      client_id: privateVars.get(this).clientId,
+      redirect_uri: constants.AUTH0_CALLBACK_URL,
+      code_challenge: verifierChallenge,
+      code_challenge_method: 'S256'
+    });
     // Open a browser and initiate the authentication process with Auth0
     // The callback URL is a simple website that simply displays the OAuth2 authz code
     // User will copy the value and then paste it here for the process to complete.
-    opn(constants.AUTH0_URL +
-      '/authorize' +
-      '?response_type=code' +
-      '&scope=openid refreshIdTokenBeforeSeconds serviceSettingsUrl' +
-      '&client_id=' + privateVars.get(this).clientId +
-      '&redirect_uri=' + constants.AUTH0_CALLBACK_URL +
-      '&code_challenge=' + verifierChallenge +
-      '&code_challenge_method=S256', {wait: false});
+    opn(`${constants.AUTH0_URL}/authorize?${qs}`, {wait: false});
 
     console.log('A browser has been opened to allow you to login. Once logged in, you will be granted a verification code.');
 

--- a/test/login-providers/browser.js
+++ b/test/login-providers/browser.js
@@ -2,6 +2,7 @@
 
 const test = require('ava');
 const proxyquire = require('proxyquire');
+const querystring = require('querystring');
 
 const requestMock = require('../helpers/request.js');
 const loginProviderBaseMock = require('../helpers/login-provider-base.js');
@@ -71,14 +72,15 @@ test.cb('login() should call opn with correct data in url', (t) => {
     'inquirer': t.context.inquirer,
     'request': t.context.request,
     'opn': (url, options) => {
-      t.is(url, constants.AUTH0_URL +
-        '/authorize' +
-        '?response_type=code' +
-        '&scope=openid refreshIdTokenBeforeSeconds serviceSettingsUrl' +
-        '&client_id=' + CLIENT_ID +
-        '&redirect_uri=' + constants.AUTH0_CALLBACK_URL +
-        '&code_challenge=' + VERIFIER_CHALLENGE +
-        '&code_challenge_method=S256');
+      const expectedQS = querystring.stringify({
+        response_type: 'code',
+        scope: 'openid refreshIdTokenBeforeSeconds serviceSettingsUrl',
+        client_id: CLIENT_ID,
+        redirect_uri: constants.AUTH0_CALLBACK_URL,
+        code_challenge: VERIFIER_CHALLENGE,
+        code_challenge_method: 'S256'
+      });
+      t.is(url, `${constants.AUTH0_URL}/authorize?${expectedQS}`);
       t.deepEqual(options, {
         wait: false
       });


### PR DESCRIPTION
## [Unreleased]
### [Fixed]
- Querystring passed to opn is now correctly escaped (@simonmarklar)